### PR TITLE
Rhythm wheels mp3export bugfix

### DIFF
--- a/Rhythm Wheels/rhythm_wheels.js
+++ b/Rhythm Wheels/rhythm_wheels.js
@@ -710,7 +710,6 @@ let RhythmWheels = function() {
     testPlay.buffer = recordWheelBuffer;
     testPlay.connect(ac.destination);
     if (!toExportIn) {
-      // TODO- determine whether to export or just for playing
       recordedBufferSource = testPlay;
     } else {
       recordedBufferSourceExport = testPlay;
@@ -721,7 +720,7 @@ let RhythmWheels = function() {
   let play = function() {
     recordedBufferSource = '';
     let sequences = compile();
-    recordedAudioBufferFill(wc.rapW.loopCount);
+    recordedAudioBufferFill(wc.rapW.loopCount, false);
     // iterate first through wheels, then iterate through nodes
     for (let i = 0; i < sequences.length; i++) {
       wc.wheels[i].setPlaying(true);


### PR DESCRIPTION
Found a bug in rhythm wheels GUI (not currently up on RW website, but in the repo) that was traced to how the rap wheel audio was handled for exporting and for playing music. If a user created a rhythm (whether or not recording was made), played it, and mp3 exported it, it would not be able to play again because of how the Rap wheel has different tasks depending on it being played vs exported. Fixed by following the same pattern as the rhythm wheels audio buffers, in which different data is stored depending on if the user is playing or exporting.