### PR TITLE
Move sound tiles as upper horizontal scroll

### DIFF
--- a/Rhythm Wheels/main.css
+++ b/Rhythm Wheels/main.css
@@ -19,8 +19,6 @@ body {
     overflow: hidden !important;
     border-radius: .25rem !important;
     color: white !important;
-    /* background: white; */
-    /* background: green; */
 
     background: #3C444D;
     font-family: 'Open Sans';
@@ -153,27 +151,18 @@ body {
     white-space: nowrap;
     margin-top: 30px;
     margin-left: 30%;
-    /* overflow-y: hidden; */
-    /* text-align: center; */
-
-    /* display: grid;
-    grid-template-columns: auto auto auto;
-    grid-template-rows: auto auto auto;
-    height: 30%;
-    max-height: 300px;
-    text-align: center;
-    overflow-y: scroll; */
 }
 
 #sound_palette .sound_tile {
     vertical-align: top;
     text-align: center;
+    padding: 0x;
 }
 
 .sound_tile {
     display: inline-block;
     text-align: center;
-    margin: 10px auto;
+    margin: 10px 0px;
 
     cursor: -webkit-grab;
     cursor: grab;
@@ -184,7 +173,7 @@ body {
 /* needed for equally spacing the wheels */
 #sound_palette:after {
     content: "";
-    width: 100%;
+    width: 20px;
     display: inline-block;
 }
 

--- a/Rhythm Wheels/main.css
+++ b/Rhythm Wheels/main.css
@@ -71,6 +71,11 @@ body {
 
 
 /* Project Settings - Speed Slider */
+
+#proj_settings{
+    margin-top: -130px;
+}
+
 .speedlabels {
     display: flex;
     justify-content: space-between;
@@ -139,13 +144,15 @@ body {
 
 /* Music Tiles - Sound Pallette */
 #sound_palette {
-    background: green;
+    background: #3C444D;
     border-radius: .25rem !important;
-    width: 500px;
+    width: 650px;
     height: auto;
     overflow-x: scroll;
     display: inline-block;
     white-space: nowrap;
+    margin-top: 30px;
+    margin-left: 30%;
     /* overflow-y: hidden; */
     /* text-align: center; */
 
@@ -171,7 +178,7 @@ body {
     cursor: -webkit-grab;
     cursor: grab;
 
-    width: 110px;
+    width: 130px;
 }
 
 /* needed for equally spacing the wheels */
@@ -253,7 +260,8 @@ body {
 
 #rhythm_wheels_container {
     width: auto;
-
+    /* position: absolute; */
+    /* left: 100px; */
 
     padding-top: 15vh;
     /* min-width: 800px; */
@@ -264,8 +272,8 @@ body {
 
 #wheels {
     text-align: center;
-
-    margin: 0 15px;
+    margin-top: -100px;
+    /* margin: 0 15px; */
 }
 
 .wheel_container {

--- a/Rhythm Wheels/main.css
+++ b/Rhythm Wheels/main.css
@@ -139,13 +139,23 @@ body {
 
 /* Music Tiles - Sound Pallette */
 #sound_palette {
-    display: grid;
+    background: green;
+    border-radius: .25rem !important;
+    width: 500px;
+    height: auto;
+    overflow-x: scroll;
+    display: inline-block;
+    white-space: nowrap;
+    /* overflow-y: hidden; */
+    /* text-align: center; */
+
+    /* display: grid;
     grid-template-columns: auto auto auto;
     grid-template-rows: auto auto auto;
     height: 30%;
     max-height: 300px;
     text-align: center;
-    overflow-y: scroll;
+    overflow-y: scroll; */
 }
 
 #sound_palette .sound_tile {
@@ -161,7 +171,7 @@ body {
     cursor: -webkit-grab;
     cursor: grab;
 
-    width: 70px;
+    width: 110px;
 }
 
 /* needed for equally spacing the wheels */

--- a/Rhythm Wheels/main.css
+++ b/Rhythm Wheels/main.css
@@ -9,15 +9,19 @@ body {
 #sidenav {
     width: 30%;
     max-height: 100vh;
+    height: 70%;
 }
 
 /* Cards */
 .ts-card {
+    height: 1px;
     box-shadow: 0 10px 15px -3px rgba(0, 0, 0, .1), 0 4px 6px -2px rgba(0, 0, 0, .05) !important;
     overflow: hidden !important;
     border-radius: .25rem !important;
-    height: 100%;
     color: white !important;
+    /* background: white; */
+    /* background: green; */
+
     background: #3C444D;
     font-family: 'Open Sans';
 }

--- a/Rhythm Wheels/rhythm_wheels.html
+++ b/Rhythm Wheels/rhythm_wheels.html
@@ -176,7 +176,7 @@
         </div>
       </div>
 
-      <div id="sound_palette">hello there</div>
+      <div class="h-25" id="sound_palette"></div>
       
       <div id="rhythm_wheels_container" class="mx-auto">
         <!-- <h2 class="display-4">Sound Palette</h2> -->

--- a/Rhythm Wheels/rhythm_wheels.html
+++ b/Rhythm Wheels/rhythm_wheels.html
@@ -104,6 +104,7 @@
   </nav>
 
   <div class="container-fluid">
+    <div class="h-25" id="sound_palette"></div>
     <div class="row">
       <div class="col-2 play-stop">
         <div class="row mx-auto">
@@ -123,7 +124,7 @@
       <div id="sidenav" class="pt-3">
         
         <!-- Project Settings -->
-        <div class='ts-card mx-auto h-75 mb-2 psettings'>
+        <div class='ts-card mx-auto h-75 mb-2 psettings' id='proj_settings'>
           <div class='ts-section'>
             <div class='ts-header'>Project Settings</div>
 
@@ -176,8 +177,6 @@
         </div>
       </div>
 
-      <div class="h-25" id="sound_palette"></div>
-      
       <div id="rhythm_wheels_container" class="mx-auto">
         <!-- <h2 class="display-4">Sound Palette</h2> -->
         <!-- <button type="button" class="btn btn-primary" data-toggle="modal" data-target="#savingModal"><i

--- a/Rhythm Wheels/rhythm_wheels.html
+++ b/Rhythm Wheels/rhythm_wheels.html
@@ -123,7 +123,7 @@
       <div id="sidenav" class="pt-3">
         
         <!-- Project Settings -->
-        <div class='ts-card mx-auto mb-2 psettings'>
+        <div class='ts-card mx-auto h-75 mb-2 psettings'>
           <div class='ts-section'>
             <div class='ts-header'>Project Settings</div>
 
@@ -167,11 +167,16 @@
               </div>
             </form>
           </div>
-          <div id="sound_palette">
+          
+          
+            <!-- TODO -- MOVING TILES ABOVE -->
+             <!-- <div id="sound_palette">
 
-          </div>
+          </div> -->
         </div>
       </div>
+
+      <div id="sound_palette">hello there</div>
       
       <div id="rhythm_wheels_container" class="mx-auto">
         <!-- <h2 class="display-4">Sound Palette</h2> -->

--- a/Rhythm Wheels/rhythm_wheels.js
+++ b/Rhythm Wheels/rhythm_wheels.js
@@ -41,8 +41,9 @@ let RhythmWheels = function() {
   let sounds = {};
 
   let libraries = {
-    'HipPop': ['rest', 'scratch11', 'scratch12', 'scratch13', 'hup1',
-      'clap1', 'tube1', 'bassdrum1', 'hihat1', 'bass-drum-reverb',
+    'HipPop': ['rest', 'scratch11',
+    //  'scratch12', 'scratch13', 'hup1',
+    //   'clap1', 'tube1', 'bassdrum1', 'hihat1', 'bass-drum-reverb',
     ],
     'LatinoCarribean': ['rest', 'open1', 'tip1', 'slap1', 'heel1', 'neck1',
       'mouth1', 'clave1', 'maracas1', 'tamborine1', 'clap4', 'openhighconga4', 'congaslap',
@@ -78,15 +79,18 @@ let RhythmWheels = function() {
    * Contructs and manages the sound palette
    */
   function SoundPalette() {
+    // TODO - move where the div for sound palette id is to the upper portion of page
     this.domelement = document.getElementById(constants.sound_palette_id);
     this.soundTiles = [];
   }
 
   SoundPalette.prototype.newSoundTile = function(opts) {
     let st = new SoundTile(opts);
+    console.log(st);
     this.soundTiles.push(st);
 
     this.domelement.appendChild(st.domelement);
+    console.log(st.domelement);
   };
 
   SoundPalette.prototype.clearPalette = function() {

--- a/Rhythm Wheels/rhythm_wheels.js
+++ b/Rhythm Wheels/rhythm_wheels.js
@@ -41,9 +41,8 @@ let RhythmWheels = function() {
   let sounds = {};
 
   let libraries = {
-    'HipPop': ['rest', 'scratch11',
-    //  'scratch12', 'scratch13', 'hup1',
-    //   'clap1', 'tube1', 'bassdrum1', 'hihat1', 'bass-drum-reverb',
+    'HipPop': ['rest', 'scratch11', 'scratch12', 'scratch13', 'hup1',
+      'clap1', 'tube1', 'bassdrum1', 'hihat1', 'bass-drum-reverb',
     ],
     'LatinoCarribean': ['rest', 'open1', 'tip1', 'slap1', 'heel1', 'neck1',
       'mouth1', 'clave1', 'maracas1', 'tamborine1', 'clap4', 'openhighconga4', 'congaslap',


### PR DESCRIPTION
Moved sound tiles to be above the rhythm wheels, contained in a horizontal scrolling bar like menu. To change the sounds displayed the student can simply change the sound category in the left-hand menu card just like before.