### PR TITLE
Enable drag and dropping tiles from wheel to wheel

### DIFF
--- a/Rhythm Wheels/rhythm_wheels.js
+++ b/Rhythm Wheels/rhythm_wheels.js
@@ -36,6 +36,7 @@ let RhythmWheels = function() {
     playing: false,
     newProject: true,
     modifiedSinceLastSave: false,
+    dragFromNode: false,
   };
 
   let sounds = {};
@@ -160,6 +161,8 @@ let RhythmWheels = function() {
       _self.tmpSprite.style['left'] = event.clientX - 25 + 'px';
       _self.tmpSprite.style['top'] = event.clientY - 25 + 'px';
       flags.dragging = _self;
+      flags.dragFromNode = false;
+      console.log(_self);
       captureMouseEvents(event);
     });
   }
@@ -225,6 +228,7 @@ let RhythmWheels = function() {
    *  opts.type: type of sound tile to set this node to
    */
   function Node(opts) {
+    // NODE IS HOW WE REPRESENT WHEEL TILES
     this.parent = opts.parent;
     this.runOnce = '';
     this.radius = 100;
@@ -248,8 +252,22 @@ let RhythmWheels = function() {
 
     let _self = this;
 
+    this.domelement.addEventListener('mousedown', function(event) {
+      // When user clicks, sound plays
+      // _self.tmpSprite.style['display'] = 'block';
+      // _self.tmpSprite.style['left'] = event.clientX - 25 + 'px';
+      // _self.tmpSprite.style['top'] = event.clientY - 25 + 'px';
+      flags.dragging = _self;
+      flags.dragFromNode = true;
+      console.log('mouse down on node!');
+      console.log(_self);
+      // captureMouseEvents(event);
+    });
+
     this.domelement.addEventListener('drop', function() {
       interrupt();
+      console.log('DROPPING');
+      console.log(_self);
       _self.setType(flags.dragging.type);
       flags.dragging = null;
     });
@@ -271,10 +289,13 @@ let RhythmWheels = function() {
     img.style['top'] = '10px';
 
     let _self = this;
-    img.addEventListener('drop', function() {
-      _self.domelement.dispatchEvent(new DragEvent('drop'));
-    });
-
+    // don't create event listener if dragging from node
+    console.log(flags.dragFromNode);
+    if (!flags.dragFromNode) {
+      img.addEventListener('drop', function() {
+        _self.domelement.dispatchEvent(new DragEvent('drop'));
+      });
+    }
     img.addEventListener('dragover', function() {
       _self.domelement.dispatchEvent(new DragEvent('dragover'));
     });

--- a/Rhythm Wheels/rhythm_wheels.js
+++ b/Rhythm Wheels/rhythm_wheels.js
@@ -162,7 +162,6 @@ let RhythmWheels = function() {
       _self.tmpSprite.style['top'] = event.clientY - 25 + 'px';
       flags.dragging = _self;
       flags.dragFromNode = false;
-      console.log(_self);
       captureMouseEvents(event);
     });
   }
@@ -253,21 +252,12 @@ let RhythmWheels = function() {
     let _self = this;
 
     this.domelement.addEventListener('mousedown', function(event) {
-      // When user clicks, sound plays
-      // _self.tmpSprite.style['display'] = 'block';
-      // _self.tmpSprite.style['left'] = event.clientX - 25 + 'px';
-      // _self.tmpSprite.style['top'] = event.clientY - 25 + 'px';
       flags.dragging = _self;
       flags.dragFromNode = true;
-      console.log('mouse down on node!');
-      console.log(_self);
-      // captureMouseEvents(event);
     });
 
     this.domelement.addEventListener('drop', function() {
       interrupt();
-      console.log('DROPPING');
-      console.log(_self);
       _self.setType(flags.dragging.type);
       flags.dragging = null;
     });
@@ -289,8 +279,6 @@ let RhythmWheels = function() {
     img.style['top'] = '10px';
 
     let _self = this;
-    // don't create event listener if dragging from node
-    console.log(flags.dragFromNode);
     if (!flags.dragFromNode) {
       img.addEventListener('drop', function() {
         _self.domelement.dispatchEvent(new DragEvent('drop'));


### PR DESCRIPTION
Rhythm wheels drag tiles from wheel node to other wheel node. This makes it easier for students to 'copy' tiles in wheel nodes that they've already laid down, versus having to go to the sound tile panel each time to drag their desired tile.